### PR TITLE
fix(deps): resolve jsondiffpatch prototype pollution (Dependabot #100)

### DIFF
--- a/src/app/package-lock.json
+++ b/src/app/package-lock.json
@@ -7803,9 +7803,9 @@
       }
     },
     "node_modules/jsondiffpatch": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.7.3.tgz",
-      "integrity": "sha512-zd4dqFiXSYyant2WgSXAZ9+yYqilNVvragVNkNRn2IFZKgjyULNrKRznqN4Zon0MkLueCg+3QaPVCnDAVP20OQ==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.7.6.tgz",
+      "integrity": "sha512-zE9+AXFq+MkTolDor2Cw1nJzLC0aleqPkYf52Kb4Kn4mJcka/gFHpGI2JBVEJCfWOvBl0OoxZS+wuLdislQcqg==",
       "license": "MIT",
       "dependencies": {
         "@dmsnell/diff-match-patch": "^1.1.0"

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -64,7 +64,7 @@
       "serialize-javascript": "^7.0.5"
     },
     "jotai-devtools": {
-      "jsondiffpatch": "^0.7.2"
+      "jsondiffpatch": "^0.7.6"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert #100: jsondiffpatch patch APIs are vulnerable to prototype pollution
- The vulnerable version was pinned via an existing `overrides` entry for `jotai-devtools` -> `jsondiffpatch` at `^0.7.2`, which resolved to the vulnerable `0.7.3`
- Bumped the override to `^0.7.6` (earliest patched release), which still satisfies `jotai-devtools`'s own `^0.7.2` requirement, so no downgrade of `jotai-devtools` is needed
- Ran `npm install` to regenerate `package-lock.json`; `jsondiffpatch` now resolves to `0.7.6`, `jotai-devtools` stays at `0.14.0`

## Test plan
- [x] `npm install` completes with 0 vulnerabilities reported
- [x] `npm run build` succeeds
- [x] Verified `package-lock.json` shows `jsondiffpatch@0.7.6` and `jotai-devtools@0.14.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)